### PR TITLE
Add Color presenter for Use Case + fix defect between Legacy IDs and V2 IDs

### DIFF
--- a/lib/santa_maria/gateway/santa_maria_v2.rb
+++ b/lib/santa_maria/gateway/santa_maria_v2.rb
@@ -47,9 +47,11 @@ module SantaMaria
 
       def all_colors
         response_colors = get(URI("#{endpoint}api/v2/colors"))['colors']
-        response_colors.map do |response_color|
-          new_color(response_color)
-        end
+        response_colors.map do |global_color|
+          global_color['colorCollections'].map do |color_collection|
+            new_color(global_color['rgb'], color_collection['colorCollectionColorId'])
+          end
+        end.flatten
       end
 
       private
@@ -93,10 +95,10 @@ module SantaMaria
         variant
       end
 
-      def new_color(color_data)
+      def new_color(rgb, color_collection_color_id)
         color = SantaMaria::Domain::Color.new
-        color.color_id = color_data['colorId']
-        color.rgb = color_data['rgb']
+        color.color_id = color_collection_color_id
+        color.rgb = rgb
         color
       end
     end

--- a/lib/santa_maria/presenter/in_memory.rb
+++ b/lib/santa_maria/presenter/in_memory.rb
@@ -1,10 +1,11 @@
 module SantaMaria
   module Presenter
     class InMemory
-      attr_accessor :products
+      attr_accessor :products, :colors
 
       def initialize
         @products = []
+        @colors = []
       end
 
       def product(id:, type:, name:, uri_name:, description:, image_url:)
@@ -42,6 +43,13 @@ module SantaMaria
         product[:variants] << variant
 
         variant
+      end
+
+      def color(id:, rgb:)
+        colors << {
+          id: id,
+          rgb: rgb
+        }
       end
     end
   end

--- a/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
+++ b/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
@@ -315,16 +315,33 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
       end
     end
 
-    context 'two colors' do
+    context 'two global colors, each with two color collection ids each' do
       let(:api_colors_response) do
         [
           {
-            colorId: "1032530",
+            colorId: "10",
             rgb: "B1AFB1",
+            colorCollections: [
+              {
+                colorCollectionColorId: "1032530",
+              },
+              {
+                colorCollectionColorId: "2032550"
+              }
+            ]
           },
           {
             colorId: "1032534",
-            rgb: "A1AD62"
+            rgb: "A1AD62",
+            colorCollections: [
+              {
+                colorCollectionColorId: "3032510",
+              },
+              {
+                colorCollectionColorId: "4032520"
+              }
+            ]
+
           }
         ]
       end
@@ -336,13 +353,21 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
             rgb: "B1AFB1",
           },
           {
-            color_id: "1032534",
+            color_id: "2032550",
+            rgb: "B1AFB1"
+          },
+          {
+            color_id: "3032510",
+            rgb: "A1AD62"
+          },
+          {
+            color_id: "4032520",
             rgb: "A1AD62"
           }
         ]
       end
 
-      it 'returns all colors' do
+      it 'flattens each color collection color id with its rgb value' do
         expected = expected_colors.map do |expected_color|
           a_color(expected_color)
         end

--- a/spec/santa_maria/unit/presenter/in_memory_spec.rb
+++ b/spec/santa_maria/unit/presenter/in_memory_spec.rb
@@ -50,4 +50,22 @@ RSpec.describe SantaMaria::Presenter::InMemory do
       expect(subject.products[0][:variants]).to eq([variant_data_without_id])
     end
   end
+
+  describe '#colors' do
+    it 'defaults to empty array' do
+      expect(subject.colors).to eq([])
+    end
+
+    let(:color) do
+      {
+        id: '123456',
+        rgb: 'FFEEDD'
+      }
+    end
+
+    it 'appends a color to the colors array' do
+      subject.color(color)
+      expect(subject.colors).to eq([color])
+    end
+  end
 end


### PR DESCRIPTION
In SantaMaria V2 the "colorID" field is now a global color ID which
is the same for every branded version of a color.

The SantaMaria Legacy "colorID" is called a "colorCollectionColorId"
in V2, and a single V2 color can have multiple branded versions of
the same color.
