### PR TITLE
Import every colorCollectionColor as a variant

### DIFF
--- a/lib/santa_maria/gateway/santa_maria_v2.rb
+++ b/lib/santa_maria/gateway/santa_maria_v2.rb
@@ -32,12 +32,14 @@ module SantaMaria
             variants << new_variant(sku)
           else
             sku['colorIds'].each do |color|
-              variant = new_variant(sku)
 
-              variant.name = color.dig('colorCollectionColors', 0, 'colorTranslation')
-              variant.color_id = color.dig('colorCollectionColors', 0, 'colorCollectionColorID')
+              color['colorCollectionColors'].each do |color_collection_color|
+                variant = new_variant(sku)
+                variant.name = color_collection_color['colorTranslation']
+                variant.color_id = color_collection_color['colorCollectionColorID']
+                variants << variant
+              end
 
-              variants << variant
             end
           end
         end

--- a/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
+++ b/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
@@ -184,8 +184,12 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                     {
                       colorCollectionColors: [
                         {
-                          colorCollectionColorID: '1000001',
-                          colorTranslation: 'Pure Brilliant Green'
+                          colorCollectionColorID: '1186982',
+                          colorTranslation: 'NORDIC SAILS 2'
+                        },
+                        {
+                          colorCollectionColorID: '1811241',
+                          colorTranslation: 'Heart Wood'
                         }
                       ]
                     }
@@ -262,8 +266,15 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 article_number: '92817271',
                 price: '19.20',
                 ready_mix: true,
-                color_id: '1000001',
-                name: 'Pure Brilliant Green'
+                color_id: '1186982',
+                name: 'NORDIC SAILS 2'
+              },
+              {
+                article_number: '92817271',
+                price: '19.20',
+                ready_mix: true,
+                color_id: '1811241',
+                name: 'Heart Wood'
               },
               { article_number: '18211221', ready_mix: true }
             ]


### PR DESCRIPTION
A single color can be sold under multiple names, e.g. Nordic Sails 2
when it was rebranded Heart Wood when it became color of the year
2018.