### PR TITLE
Export version of the API used to import products and the tinting id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    santa_maria-product_importer (0.1.0)
+    santa_maria-product_importer (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/santa_maria/domain/variant.rb
+++ b/lib/santa_maria/domain/variant.rb
@@ -8,7 +8,8 @@ module SantaMaria
                     :pattern,
                     :ean,
                     :name,
-                    :version
+                    :version,
+                    :tinting_id
 
       attr_writer :valid,
                   :on_sale,

--- a/lib/santa_maria/domain/variant.rb
+++ b/lib/santa_maria/domain/variant.rb
@@ -7,7 +7,8 @@ module SantaMaria
                     :pack_size,
                     :pattern,
                     :ean,
-                    :name
+                    :name,
+                    :version
 
       attr_writer :valid,
                   :on_sale,

--- a/lib/santa_maria/gateway/santa_maria_legacy.rb
+++ b/lib/santa_maria/gateway/santa_maria_legacy.rb
@@ -40,6 +40,7 @@ module SantaMaria
           variant.valid = package['validEcomData']
           variant.on_sale = package['readyForSale']
           variant.ready_mix = !package['tintedOrReadyMix'].eql?('Tinted')
+          variant.version = '0'
 
           variant
         end

--- a/lib/santa_maria/gateway/santa_maria_v2.rb
+++ b/lib/santa_maria/gateway/santa_maria_v2.rb
@@ -95,6 +95,7 @@ module SantaMaria
         variant.on_sale = sku['readyForSale'] == 'true' unless sku['readyForSale'].nil?
         variant.ready_mix = !sku['tintedOrReadyMix'].eql?('Tinted')
         variant.version = '2'
+        variant.tinting_id = sku.dig('genericTintingId')
         variant
       end
 

--- a/lib/santa_maria/gateway/santa_maria_v2.rb
+++ b/lib/santa_maria/gateway/santa_maria_v2.rb
@@ -94,6 +94,7 @@ module SantaMaria
         variant.valid = sku['validEcomData'] == 'true' unless sku['validEcomData'].nil?
         variant.on_sale = sku['readyForSale'] == 'true' unless sku['readyForSale'].nil?
         variant.ready_mix = !sku['tintedOrReadyMix'].eql?('Tinted')
+        variant.version = '2'
         variant
       end
 

--- a/lib/santa_maria/presenter/in_memory.rb
+++ b/lib/santa_maria/presenter/in_memory.rb
@@ -25,7 +25,8 @@ module SantaMaria
       end
 
       def variant(id:, article_number:, price:, valid:, on_sale:, color_id:,
-                  ready_mix:, pack_size:, pattern:, ean:, name:, version:)
+                  ready_mix:, pack_size:, pattern:, ean:, name:, version:,
+                  tinting_id:)
         product = products.detect { |p| p[:id] == id }
         variant = {
           article_number: article_number,
@@ -38,7 +39,8 @@ module SantaMaria
           pattern: pattern,
           ean: ean,
           name: name,
-          version: version
+          version: version,
+          tinting_id: tinting_id
         }
 
         product[:variants] << variant

--- a/lib/santa_maria/presenter/in_memory.rb
+++ b/lib/santa_maria/presenter/in_memory.rb
@@ -25,7 +25,7 @@ module SantaMaria
       end
 
       def variant(id:, article_number:, price:, valid:, on_sale:, color_id:,
-                  ready_mix:, pack_size:, pattern:, ean:, name:)
+                  ready_mix:, pack_size:, pattern:, ean:, name:, version:)
         product = products.detect { |p| p[:id] == id }
         variant = {
           article_number: article_number,
@@ -37,7 +37,8 @@ module SantaMaria
           pack_size: pack_size,
           pattern: pattern,
           ean: ean,
-          name: name
+          name: name,
+          version: version
         }
 
         product[:variants] << variant

--- a/lib/santa_maria/product_importer/version.rb
+++ b/lib/santa_maria/product_importer/version.rb
@@ -1,5 +1,5 @@
 module SantaMaria
   module ProductImporter
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/lib/santa_maria/use_case/fetch_products.rb
+++ b/lib/santa_maria/use_case/fetch_products.rb
@@ -35,7 +35,8 @@ module SantaMaria
               pattern: variant.pattern == '' ? nil : variant.pattern,
               ean: variant.ean == '' ? nil : variant.ean,
               name: variant.name,
-              version: variant.version
+              version: variant.version,
+              tinting_id: variant.tinting_id
             )
           end
         end

--- a/lib/santa_maria/use_case/fetch_products.rb
+++ b/lib/santa_maria/use_case/fetch_products.rb
@@ -34,7 +34,8 @@ module SantaMaria
               pack_size: variant.pack_size,
               pattern: variant.pattern == '' ? nil : variant.pattern,
               ean: variant.ean == '' ? nil : variant.ean,
-              name: variant.name
+              name: variant.name,
+              version: variant.version
             )
           end
         end

--- a/spec/santa_maria/acceptance/santa_maria_spec.rb
+++ b/spec/santa_maria/acceptance/santa_maria_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe 'santa maria' do
     end
   end
 
+  def fetch_products
+    product_requests
+    products_request
+    subject
+  end
+
   context 'given two products with a variant' do
     let(:token) { 'sometoken '}
 
@@ -34,11 +40,7 @@ RSpec.describe 'santa maria' do
         use_case.execute(presenter: spy_presenter)
       end
 
-      before do
-        product_requests
-        products_request
-        subject
-      end
+      before { fetch_products }
 
       it 'is able to extract the products' do
         product_1 = spy_presenter.products[0]
@@ -69,6 +71,7 @@ RSpec.describe 'santa maria' do
         expect(variant_1[:pattern]).to be_nil
         expect(variant_1[:ean]).to eq('11111112981722')
         expect(variant_1[:name]).to eq('Radioactive Orange')
+        expect(variant_1[:version]).to eq(expected_version)
 
         variant_2 = spy_presenter.variants[1]
         expect(variant_2[:id]).to eq('192871-19291-39192-982910')
@@ -82,6 +85,7 @@ RSpec.describe 'santa maria' do
         expect(variant_2[:pattern]).to eq('square-print')
         expect(variant_2[:ean]).to eq('22222221827162')
         expect(variant_2[:name]).to eq('Pure Brilliant Red')
+        expect(variant_2[:version]).to eq(expected_version)
 
         variant_3 = spy_presenter.variants[2]
         expect(variant_3[:id]).to eq('192871-19291-39192-982910')
@@ -95,6 +99,7 @@ RSpec.describe 'santa maria' do
         expect(variant_3[:pattern]).to be_nil
         expect(variant_3[:ean]).to be_nil
         expect(variant_3[:name]).to be_nil
+        expect(variant_3[:version]).to eq(expected_version)
       end
     end
 
@@ -113,6 +118,7 @@ RSpec.describe 'santa maria' do
     end
 
     describe 'legacy' do
+      let(:expected_version) { '0' }
       let(:product_requests) do
         product_1 = {
           packages: [
@@ -210,6 +216,7 @@ RSpec.describe 'santa maria' do
     end
 
     describe 'v2' do
+      let(:expected_version) { '2' }
       let(:product_requests) do
         product_1 = {
           sku: [
@@ -252,6 +259,7 @@ RSpec.describe 'santa maria' do
                   ]
                 }
               ],
+              genericTintingId: '1234567',
               tintedOrReadyMix: 'Tinted',
               friendlyPackSizeTranslation: '2.5L',
               pattern: [

--- a/spec/santa_maria/acceptance/santa_maria_spec.rb
+++ b/spec/santa_maria/acceptance/santa_maria_spec.rb
@@ -213,6 +213,24 @@ RSpec.describe 'santa maria' do
       end
 
       include_examples 'product data'
+
+      context 'tinting id' do
+        let(:endpoint) { 'https://api' }
+
+        it 'contains a nil for all products' do
+          spy_presenter = SpyPresenter.new
+          use_case = SantaMaria::UseCase::FetchProducts.new(
+            santa_maria: santa_maria
+          )
+
+          fetch_products 
+          use_case.execute(presenter: spy_presenter)
+
+          expect(spy_presenter.variants[0][:tinting_id]).to be_nil
+          expect(spy_presenter.variants[1][:tinting_id]).to be_nil
+          expect(spy_presenter.variants[2][:tinting_id]).to be_nil
+        end
+      end
     end
 
     describe 'v2' do
@@ -342,6 +360,24 @@ RSpec.describe 'santa maria' do
       end
 
       include_examples 'product data'
+
+      context 'tinting id' do
+        let(:endpoint) { 'https://api' }
+
+        it 'contains the tinting_id for tinted products' do
+          spy_presenter = SpyPresenter.new
+          use_case = SantaMaria::UseCase::FetchProducts.new(
+            santa_maria: santa_maria
+          )
+
+          fetch_products 
+          use_case.execute(presenter: spy_presenter)
+
+          expect(spy_presenter.variants[0][:tinting_id]).to be_nil
+          expect(spy_presenter.variants[1][:tinting_id]).to eq('1234567')
+          expect(spy_presenter.variants[2][:tinting_id]).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/santa_maria/unit/gateway/santa_maria_legacy_spec.rb
+++ b/spec/santa_maria/unit/gateway/santa_maria_legacy_spec.rb
@@ -216,7 +216,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pack_size: '5L',
                 pattern: 'square-print',
                 ean: '92817271827162',
-                name: 'Pure Brilliant Teal'
+                name: 'Pure Brilliant Teal',
+                version: '0'
               },
               {
                 article_number: '1821122',
@@ -228,7 +229,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pack_size: '2.5L',
                 pattern: 'triangle-print',
                 ean: '1010101010101010',
-                name: 'Pure Brilliant Green'
+                name: 'Pure Brilliant Green',
+                version: '0'
               }
             ]
           },
@@ -250,7 +252,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pack_size: '5L',
                 pattern: 'square-print',
                 ean: '92817271827162',
-                name: 'Pure Brilliant Teal'
+                name: 'Pure Brilliant Teal',
+                version: '0'
               },
               {
                 article_number: '18211221',
@@ -262,7 +265,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pack_size: '5L',
                 pattern: 'square-print',
                 ean: '92817271827162',
-                name: 'Pure Brilliant Teal'
+                name: 'Pure Brilliant Teal',
+                version: '0'
               }
             ]
           }

--- a/spec/santa_maria/unit/gateway/santa_maria_legacy_spec.rb
+++ b/spec/santa_maria/unit/gateway/santa_maria_legacy_spec.rb
@@ -217,7 +217,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pattern: 'square-print',
                 ean: '92817271827162',
                 name: 'Pure Brilliant Teal',
-                version: '0'
+                version: '0',
+                tinting_id: nil
               },
               {
                 article_number: '1821122',
@@ -230,7 +231,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pattern: 'triangle-print',
                 ean: '1010101010101010',
                 name: 'Pure Brilliant Green',
-                version: '0'
+                version: '0',
+                tinting_id: nil
               }
             ]
           },
@@ -253,7 +255,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pattern: 'square-print',
                 ean: '92817271827162',
                 name: 'Pure Brilliant Teal',
-                version: '0'
+                version: '0',
+                tinting_id: nil
               },
               {
                 article_number: '18211221',
@@ -266,7 +269,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaLegacy do
                 pattern: 'square-print',
                 ean: '92817271827162',
                 name: 'Pure Brilliant Teal',
-                version: '0'
+                version: '0',
+                tinting_id: nil
               }
             ]
           }

--- a/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
+++ b/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
@@ -231,7 +231,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 pack_size: '5L',
                 pattern: 'square-print',
                 ean: '92817271827162',
-                name: 'Pure Brilliant Teal'
+                name: 'Pure Brilliant Teal',
+                version: '2'
               },
               {
                 article_number: '1821122',
@@ -243,7 +244,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 pack_size: '5L',
                 pattern: nil,
                 ean: '22222221827162',
-                name: nil
+                name: nil,
+                version: '2'
               }
             ]
           },
@@ -260,23 +262,26 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 price: '19.20',
                 ready_mix: true,
                 color_id: '1827162',
-                name: 'Pure Brilliant Red'
+                name: 'Pure Brilliant Red',
+                version: '2'
               },
               {
                 article_number: '92817271',
                 price: '19.20',
                 ready_mix: true,
                 color_id: '1186982',
-                name: 'NORDIC SAILS 2'
+                name: 'NORDIC SAILS 2',
+                version: '2'
               },
               {
                 article_number: '92817271',
                 price: '19.20',
                 ready_mix: true,
                 color_id: '1811241',
-                name: 'Heart Wood'
+                name: 'Heart Wood',
+                version: '2'
               },
-              { article_number: '18211221', ready_mix: true }
+              { article_number: '18211221', ready_mix: true, version: '2' }
             ]
           }
         ]

--- a/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
+++ b/spec/santa_maria/unit/gateway/santa_maria_v2_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                       name: 'square-print'
                     }
                   ],
-                  eanCode: '92817271827162'
+                  eanCode: '92817271827162',
+                  genericTintingId: '9998887'
                 },
                 {
                   articleNumber: '1821122',
@@ -232,7 +233,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 pattern: 'square-print',
                 ean: '92817271827162',
                 name: 'Pure Brilliant Teal',
-                version: '2'
+                version: '2',
+                tinting_id: '9998887'
               },
               {
                 article_number: '1821122',
@@ -245,7 +247,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 pattern: nil,
                 ean: '22222221827162',
                 name: nil,
-                version: '2'
+                version: '2',
+                tinting_id: nil
               }
             ]
           },
@@ -263,7 +266,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 ready_mix: true,
                 color_id: '1827162',
                 name: 'Pure Brilliant Red',
-                version: '2'
+                version: '2',
+                tinting_id: nil
               },
               {
                 article_number: '92817271',
@@ -271,7 +275,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 ready_mix: true,
                 color_id: '1186982',
                 name: 'NORDIC SAILS 2',
-                version: '2'
+                version: '2',
+                tinting_id: nil
               },
               {
                 article_number: '92817271',
@@ -279,7 +284,8 @@ RSpec.describe SantaMaria::Gateway::SantaMariaV2 do
                 ready_mix: true,
                 color_id: '1811241',
                 name: 'Heart Wood',
-                version: '2'
+                version: '2',
+                tinting_id: nil
               },
               { article_number: '18211221', ready_mix: true, version: '2' }
             ]

--- a/spec/santa_maria/unit/presenter/in_memory_spec.rb
+++ b/spec/santa_maria/unit/presenter/in_memory_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe SantaMaria::Presenter::InMemory do
       pattern: '',
       ean: '9900990099',
       name: 'Red',
-      version: '2'
+      version: '2',
+      tinting_id: '1234567'
     }
   end
 

--- a/spec/santa_maria/unit/presenter/in_memory_spec.rb
+++ b/spec/santa_maria/unit/presenter/in_memory_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe SantaMaria::Presenter::InMemory do
       pack_size: 'm',
       pattern: '',
       ean: '9900990099',
-      name: 'Red'
+      name: 'Red',
+      version: '2'
     }
   end
 

--- a/spec/santa_maria/unit/use_case/fetch_products_spec.rb
+++ b/spec/santa_maria/unit/use_case/fetch_products_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: '',
               ean: 'ANEAN',
               name: 'Green',
-              version: '2'
+              version: '2',
+              tinting_id: '9998887'
             ),
             double(
               article_number: '182356',
@@ -60,8 +61,9 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: 'weather-stripes',
               ean: '1928172376162',
               name: 'Teal',
-              version: '2'
-            ),
+              version: '2',
+              tinting_id: nil
+            )
           ]
         )
         products << double(
@@ -83,7 +85,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: 'weather-stripes',
               ean: '1928172376162',
               name: 'Orange',
-              version: '3'
+              version: '3',
+              tinting_id: nil
             ),
             double(
               article_number: '192811',
@@ -96,8 +99,9 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: nil,
               ean: '',
               name: 'Red',
-              version: '3'
-            ),
+              version: '3',
+              tinting_id: '7776665'
+            )
           ]
         )
       end
@@ -142,7 +146,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: nil,
               ean: 'ANEAN',
               name: 'Green',
-              version: '2'
+              version: '2',
+              tinting_id: '9998887'
             ).ordered
         )
         expect(presenter).to(
@@ -159,7 +164,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: 'weather-stripes',
               ean: '1928172376162',
               name: 'Teal',
-              version: '2'
+              version: '2',
+              tinting_id: nil
             ).ordered
         )
         expect(presenter).to(
@@ -176,7 +182,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: 'weather-stripes',
               ean: '1928172376162',
               name: 'Orange',
-              version: '3'
+              version: '3',
+              tinting_id: nil
             ).ordered
         )
         expect(presenter).to(
@@ -193,7 +200,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pattern: nil,
               ean: nil,
               name: 'Red',
-              version: '3'
+              version: '3',
+              tinting_id: '7776665'
             ).ordered
         )
       end

--- a/spec/santa_maria/unit/use_case/fetch_products_spec.rb
+++ b/spec/santa_maria/unit/use_case/fetch_products_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '5L',
               pattern: '',
               ean: 'ANEAN',
-              name: 'Green'
+              name: 'Green',
+              version: '2'
             ),
             double(
               article_number: '182356',
@@ -58,7 +59,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '2.5L',
               pattern: 'weather-stripes',
               ean: '1928172376162',
-              name: 'Teal'
+              name: 'Teal',
+              version: '2'
             ),
           ]
         )
@@ -80,7 +82,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '2.5L',
               pattern: 'weather-stripes',
               ean: '1928172376162',
-              name: 'Orange'
+              name: 'Orange',
+              version: '3'
             ),
             double(
               article_number: '192811',
@@ -92,7 +95,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '5L',
               pattern: nil,
               ean: '',
-              name: 'Red'
+              name: 'Red',
+              version: '3'
             ),
           ]
         )
@@ -137,7 +141,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '5L',
               pattern: nil,
               ean: 'ANEAN',
-              name: 'Green'
+              name: 'Green',
+              version: '2'
             ).ordered
         )
         expect(presenter).to(
@@ -153,7 +158,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '2.5L',
               pattern: 'weather-stripes',
               ean: '1928172376162',
-              name: 'Teal'
+              name: 'Teal',
+              version: '2'
             ).ordered
         )
         expect(presenter).to(
@@ -169,7 +175,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '2.5L',
               pattern: 'weather-stripes',
               ean: '1928172376162',
-              name: 'Orange'
+              name: 'Orange',
+              version: '3'
             ).ordered
         )
         expect(presenter).to(
@@ -185,7 +192,8 @@ RSpec.describe SantaMaria::UseCase::FetchProducts do
               pack_size: '5L',
               pattern: nil,
               ean: nil,
-              name: 'Red'
+              name: 'Red',
+              version: '3'
             ).ordered
         )
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,8 @@ RSpec::Matchers.define :a_product_with_variants do |expected_variants|
         variant.pattern == expected_variants[i][:pattern] &&
         variant.ean == expected_variants[i][:ean] &&
         variant.name == expected_variants[i][:name] &&
-        variant.version == expected_variants[i][:version]
+        variant.version == expected_variants[i][:version] &&
+        variant.tinting_id == expected_variants[i][:tinting_id]
     end
 
     !matches.include?(false)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,8 @@ RSpec::Matchers.define :a_product_with_variants do |expected_variants|
         variant.pack_size == expected_variants[i][:pack_size] &&
         variant.pattern == expected_variants[i][:pattern] &&
         variant.ean == expected_variants[i][:ean] &&
-        variant.name == expected_variants[i][:name]
+        variant.name == expected_variants[i][:name] &&
+        variant.version == expected_variants[i][:version]
     end
 
     !matches.include?(false)


### PR DESCRIPTION
As part of the SMv2 upgrade we want to keep track of the version used when importing.

Additionally we want to include the tinting_id on v2 products